### PR TITLE
Results Page Serverside Bug

### DIFF
--- a/app/(topbarlayout)/sketch-rank/[year]/results/statsParagraph.tsx
+++ b/app/(topbarlayout)/sketch-rank/[year]/results/statsParagraph.tsx
@@ -11,10 +11,10 @@ type StatsParagraphProps = {
 export default function StatsParagraph({ year }: StatsParagraphProps) {
   const [data, setData] = useState(null);
 
-  const url = new URL("/api/sketch-rank/votes-cast", window.location.origin);
-  url.searchParams.append("year", year);
-
   useEffect(() => {
+    const url = new URL("/api/sketch-rank/votes-cast", window.location.origin);
+    url.searchParams.append("year", year);
+
     // Fetch the data from your API endpoint
     fetch(url.toString())
       .then((response) => response.json())


### PR DESCRIPTION
Thanks to Google notifying me, the results page is throwing 500 errors even though its loading because the server is trying to access window.

Moving it into the useEffect statement should fix, because useEffect happens on the client.